### PR TITLE
Can now configure Docker daemon and TLS certificates via pillar data

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -13,7 +13,44 @@ Exposed state module:
 
 docker sls
 ----------
-Installs docker and configures /root/.dockercfg based on pillar['docker-registries']
+Configures /root/.dockercfg based on pillar['docker-registries'].
+
+Configures /etc/default/docker based on pillar['docker:docker_opts'], see map.jinja for defaults.  
+Example pillar:
+```
+docker:
+  docker_opts:
+    listen_socket: 'tcp://0.0.0.0:2376'
+    listen_unix_sock: 'unix:///var/run/docker.sock'
+    storage_driver: 'btrfs'
+    graph_dir: '/var/lib/docker'
+    ipv6: 'false'
+    log_driver: 'syslog'
+    tls_verify: 'true'
+    tls_ca_cert: '/etc/docker/ca.pem'
+    tls_cert: '/etc/docker/cert.pem'
+    tls_key: '/etc/docker/key.pem'
+```
+Pillar key names match the Docker daemon options.  For a full list of daemon options and their effects visit: [https://docs.docker.com/engine/reference/commandline/daemon/]
+
+Configures TLS certificates, required when pillar['docker:docker_opts:tls_verify'] is True.
+Example pillar:
+```
+docker:
+  tls:
+    ca: |
+      -----BEGIN CERTIFICATE-----
+      < certificate body >
+      -----END CERTIFICATE-----
+    key: |
+      -----BEGIN RSA PRIVATE KEY-----
+      < key body >
+      -----END RSA PRIVATE KEY-----
+    cert: |
+      -----BEGIN CERTIFICATE-----
+      < certificate body >
+      -----END CERTIFICATE-----
+```
 
 
 docker-compose sls

--- a/docker/config.sls
+++ b/docker/config.sls
@@ -1,3 +1,5 @@
+{% from 'docker/map.jinja' import docker with context %}
+
 /root/.dockercfg:
   file.managed:
     - source: salt://docker/templates/dockercfg
@@ -7,5 +9,63 @@
     - template: jinja
 
 
+{% if docker.manage_config == true %}
+/etc/default/docker:
+  file.managed:
+    - source: salt://docker/templates/docker
+    - mode: 0644
+    - user: root
+    - group: root
+    - template: jinja
+    - listen_in:
+      - service: docker
+{% endif %}
+
+
+{% if docker.tls.ca %}
+docker_tls_ca_cert:
+  file.managed:
+    - name: {{ docker.docker_opts.tls_ca_cert }}
+    - source: salt://docker/templates/ca.pem
+    - mode: 0600
+    - user: root
+    - group: root
+    - template: jinja
+    - listen_in:
+      - service: docker
+{% endif %}
+
+
+{% if docker.tls.cert %}
+docker_tls_cert:
+  file.managed:
+    - name: {{ docker.docker_opts.tls_cert }}
+    - source: salt://docker/templates/cert.pem
+    - mode: 0600
+    - user: root
+    - group: root
+    - template: jinja
+    - listen_in:
+      - service: docker
+{% endif %}
+
+
+
+{% if docker.tls.key %}
+docker_tls_key:
+  file.managed:
+    - name: {{ docker.docker_opts.tls_key }}
+    - source: salt://docker/templates/key.pem
+    - mode: 0600
+    - user: root
+    - group: root
+    - template: jinja
+    - listen_in:
+      - service: docker
+{% endif %}
+
+
 docker:
-  service.running
+  service.running:
+    - enable: True
+    - reload: True

--- a/docker/config.sls
+++ b/docker/config.sls
@@ -9,7 +9,7 @@
     - template: jinja
 
 
-{% if docker.manage_config == true %}
+{% if docker.manage_config == 'true' %}
 /etc/default/docker:
   file.managed:
     - source: salt://docker/templates/docker

--- a/docker/map.jinja
+++ b/docker/map.jinja
@@ -1,0 +1,25 @@
+{% set docker = salt['grains.filter_by']({
+    'Debian': {
+      'pkg_version': '',
+      'py_version': '',
+      'manage_config': 'false',
+      'docker_opts': {
+        'listen_socket': 'tcp://0.0.0.0:2376',
+        'listen_unix_sock': 'unix:///var/run/docker.sock',
+        'storage_driver': '',
+        'graph_dir': '',
+        'ipv6': 'false',
+        'log_driver': 'syslog',
+        'tls_verify': 'false',
+        'tls_ca_cert': '/etc/docker/ca.pem',
+        'tls_cert': '/etc/docker/cert.pem',
+        'tls_key': '/etc/docker/key.pem'
+      },
+      'tls': {
+         'ca': '',
+         'key': '',
+         'cert': ''
+       }
+    },
+'default': 'Debian',
+}, merge=salt['pillar.get']('docker',{})) %}

--- a/docker/templates/ca.pem
+++ b/docker/templates/ca.pem
@@ -1,0 +1,1 @@
+{{ salt['pillar.get']('docker:tls:ca') }}

--- a/docker/templates/cert.pem
+++ b/docker/templates/cert.pem
@@ -1,0 +1,1 @@
+{{ salt['pillar.get']('docker:tls:cert') }}

--- a/docker/templates/docker
+++ b/docker/templates/docker
@@ -1,0 +1,14 @@
+{%- from "docker/map.jinja" import docker with context -%}
+DOCKER_OPTS='
+{% if docker.docker_opts.listen_socket %}-H {{ docker.docker_opts.listen_socket }}{% endif %}
+{% if docker.docker_opts.listen_unix_sock %}-H {{ docker.docker_opts.listen_unix_sock }}{% endif %}
+{% if docker.docker_opts.storage_driver %}-s {{ docker.docker_opts.storage_driver }}{% endif %}
+{% if docker.docker_opts.graph_dir %}-g {{ docker.docker_opts.graph_dir }}{% endif %}
+{% if docker.docker_opts.ipv6 == false %}--ipv6=false{% endif %}
+{% if docker.docker_opts.log_driver %}--log-driver={{ docker.docker_opts.log_driver }}{% endif %}
+{% if docker.docker_opts.tls_verify == true %}--tlsverify
+--tlscacert {{ docker.docker_opts.tls_ca_cert}}
+--tlscert {{ docker.docker_opts.tls_cert }}
+--tlskey {{ docker.docker_opts.tls_key }}
+{% endif %}
+'

--- a/docker/templates/docker
+++ b/docker/templates/docker
@@ -4,9 +4,9 @@ DOCKER_OPTS='
 {% if docker.docker_opts.listen_unix_sock %}-H {{ docker.docker_opts.listen_unix_sock }}{% endif %}
 {% if docker.docker_opts.storage_driver %}-s {{ docker.docker_opts.storage_driver }}{% endif %}
 {% if docker.docker_opts.graph_dir %}-g {{ docker.docker_opts.graph_dir }}{% endif %}
-{% if docker.docker_opts.ipv6 == false %}--ipv6=false{% endif %}
+{% if docker.docker_opts.ipv6 == 'false' %}--ipv6=false{% endif %}
 {% if docker.docker_opts.log_driver %}--log-driver={{ docker.docker_opts.log_driver }}{% endif %}
-{% if docker.docker_opts.tls_verify == true %}--tlsverify
+{% if docker.docker_opts.tls_verify == 'true' %}--tlsverify
 --tlscacert {{ docker.docker_opts.tls_ca_cert}}
 --tlscert {{ docker.docker_opts.tls_cert }}
 --tlskey {{ docker.docker_opts.tls_key }}

--- a/docker/templates/key.pem
+++ b/docker/templates/key.pem
@@ -1,0 +1,1 @@
+{{ salt['pillar.get']('docker:tls:key') }}


### PR DESCRIPTION
Management of /etc/default/docker is disabled by default, as opg-bootstrap does some of this already.  If managing the Docker daemon config it needs to be fully configured via this state.

TLS certificates can now be added by specifying pillar data.  This is in order that a central host (ie: Jenkins) can securely communicate with remote Docker daemons.
