### PR TITLE
Opgs 1224 opg shared deploy

### DIFF
--- a/base/init.sls
+++ b/base/init.sls
@@ -3,4 +3,4 @@ include:
   - admins
   - ntp
   - cron
-  - docker-compose.services
+  - docker-service

--- a/docker-service/README.md
+++ b/docker-service/README.md
@@ -1,0 +1,100 @@
+This module is an extension fo the docker compose formula allowing the formula to deliver an ecs service or a docker compose file.
+
+The ECS and docker-compose targets are differentiated by a **type** variable determined by the pillar data location.
+
+pillar data:
+
+services:
+    <service name>: *reqd
+        type: "<compose | ecs>" *reqd (default compose)
+        config-source: *reqd (replaces docker-compose-source)
+        scripts: (compose only)
+        env_files: (compose only)
+        extra: (compose only)
+        directories:  local dirs to be created
+        volumes: volume mapping for container
+        elb: elb data (ecs only)
+        rds: rds data (ecs only)
+        dns: dns records (ecs only)
+        
+        
+elb:
+    
+        
+
+module flow:
+
+1. check if 'services' key exists in pillar
+2. loop over keys in services and extract ecs and compose types into separate dicts/lists
+3. loop over compose types if any
+4. loop over ecs types if any
+
+        
+############################
+#legacy docs
+# docker-compose-formula
+Saltstack formula for managing docker compose services and supporting directories via pillar data
+
+This formula supports both single environment files and an array of env files per service
+
+## Sample Pillar Data - Single env file, No directories ##
+
+```yml
+services:
+  admin-tasks:
+    docker-compose-source: salt://service-master/templates/docker-compose.yml
+    scripts:
+      env:
+        MONITORING_ENABLED: True
+        OPG_SERVICE: scripts
+        EBS_SNAPSHOT_RETENTION_DAYS: 8
+        EBS_SNAPSHOT_MONITOR_HOST: monitoring
+        EBS_SNAPSHOT_MONITOR_PORT: 2003
+```
+
+## Sample Pillar Data - Directory creation ##
+
+```yml
+services:
+  monitoring-server:
+    docker-compose-source: salt://monitoring/templates/compose-monitoring-server.yml
+    directories:
+      grafana:
+        path: /data/grafana
+        mode: 0775
+        user: foo
+        group: bar
+      graphite:
+        path: /data/graphite
+        mode: 0775
+      elasticsearch:
+        path: /data/elasticsearch
+```
+
+The `mode`, `user` and `group` key all have sensible defaults of  `root, root and 0755` respectively
+
+Where pillar data exists, the following values MUST be specified as default values cannot be derived:
+
+* path
+
+## Sample Pillar Data - Multiple env files for one service ##
+
+```yml
+services:
+  monitoring-client:
+    docker-compose-source: salt://monitoring/templates/compose-monitoring-client.yml
+    #Common settings for all clients
+    env_files:
+      sensuclient:
+       #Common variables
+      checksbase:
+        #Common variables
+    #Grain specific settings
+    extra:
+      checksbase_master:
+        #grain specific variables
+      checksbase_monitoring:
+        #grain specific variables
+```
+
+The names under the `extra` section are simply `env_file_name`_`grain`.

--- a/docker-service/README.md
+++ b/docker-service/README.md
@@ -1,16 +1,20 @@
-This module is an extension fo the docker compose formula allowing the formula to deliver an ecs service or a docker compose file.
+docker-service
+--------------
 
-The ECS and docker-compose targets are differentiated by a **type** variable determined by the pillar data location.
+This module is an extension of the docker compose formula allowing the formula to deliver an ecs service or a docker compose file.
+
+The ECS and docker-compose targets are differentiated by a **type** variable determined in the pillar **services** tree.
 
 pillar data:
 
 services:
     <service name>: *reqd
-        type: "<compose | ecs>" *reqd (default compose)
-        config-source: *reqd (replaces docker-compose-source)
+        type: "<compose | ecs>" (default to "compose" if not present)
+        config-source: *reqd (replaces docker-compose-source/provides src json for ecs task)
         scripts: (compose only)
         env_files: (compose only)
         extra: (compose only)
+        ecs_cluster: name of ecs cluster to deploy to (ecs only)
         directories:  local dirs to be created
         volumes: volume mapping for container
         elb: elb data (ecs only)
@@ -25,10 +29,11 @@ elb:
 module flow:
 
 1. check if 'services' key exists in pillar
-2. loop over keys in services and extract ecs and compose types into separate dicts/lists
-3. loop over compose types if any
-4. loop over ecs types if any
+2. call compose-service state which will only deploy docker-compose services
+3. call ecs-service state which will only deploy docker services to ecs
 
+
+The ecs service requires a bit more than just a compose file, so will use other aws salt modules to provision the required infrastructure for the service.
         
 ############################
 #legacy docs

--- a/docker-service/compose-service.sls
+++ b/docker-service/compose-service.sls
@@ -1,0 +1,93 @@
+/etc/docker-compose:
+  file.directory
+{% for service_name in pillar['services'] %}
+{%   if pillar['services'][service_name]['type'] | default('compose') == 'compose' %}
+
+/etc/docker-compose/{{service_name}}:
+  file.directory:
+    - user: root
+    - group: root
+    - mode: 0755
+
+{%     if 'directories' in pillar['services'][service_name] %}
+{%       for directory in pillar['services'][service_name]['directories'] %}
+
+{{ pillar['services'][service_name]['directories'][directory]['path']}}:
+  file.directory:
+    - user:  {{ pillar['services'][service_name]['directories'][directory]['user'] | default('root') }}
+    - group: {{ pillar['services'][service_name]['directories'][directory]['group'] | default('root') }}
+    - mode:  {{ pillar['services'][service_name]['directories'][directory]['mode'] | default('0755') }}
+
+{%       endfor %}
+{%     endif %}
+
+/etc/docker-compose/{{service_name}}/docker-compose.yml:
+  file.managed:
+    - source: {{pillar['services'][service_name]['docker-compose-source']}}
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 644
+
+/etc/init.d/docker-compose-{{service_name}}:
+  file.managed:
+    - source: salt://docker-compose/templates/docker-compose-service
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 755
+    - context:
+        service_name: {{service_name}}
+
+docker-compose-{{service_name}}:
+  service.running:
+    - enable: True
+    - watch:
+      - file: /etc/init.d/docker-compose-{{service_name}}
+
+
+{%     if pillar['services'][service_name]['env_files'] is defined %}
+{%       for env_name in pillar['services'][service_name]['env_files'] %}
+{%         set env_extra_test = env_name + '_' + grains['opg_role'] %}
+{%         if pillar['services'][service_name]['extra'][env_extra_test] is defined %}
+{%           set env_extra = env_extra_test %}
+{%         endif %}
+/etc/docker-compose/{{service_name}}/{{env_name}}.env:
+  file.managed:
+    - source: salt://docker-compose/templates/app.env
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 600
+    - context:
+        app_name: {{env_name}}
+        service_name: {{service_name}}
+{%       if env_extra is defined %}
+        env_extra: {{env_extra}}
+{%       endif %}
+    - watch_in:
+      - service: docker-compose-{{service_name}}
+
+{%       endfor %}
+{%     else %}
+{%       for app_name in pillar['services'][service_name] %}
+{%         if 'env' in pillar['services'][service_name][app_name] %}
+
+/etc/docker-compose/{{service_name}}/{{app_name}}.env:
+  file.managed:
+    - source: salt://docker-compose/templates/app.env
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 600
+    - context:
+        app_name: {{app_name}}
+        service_name: {{service_name}}
+    - watch_in:
+      - service: docker-compose-{{service_name}}
+
+{%         endif %}
+{%       endfor %}
+{%     endif %}
+{%   endif %}
+{% endfor %}

--- a/docker-service/compose-service.sls
+++ b/docker-service/compose-service.sls
@@ -1,5 +1,6 @@
 /etc/docker-compose:
   file.directory
+
 {% for service_name in pillar['services'] %}
 {%   if pillar['services'][service_name]['type'] | default('compose') == 'compose' %}
 

--- a/docker-service/ecs-service.sls
+++ b/docker-service/ecs-service.sls
@@ -12,12 +12,8 @@
 #  - aws_task
 #  - aws_dns
 
-{%     set service_list = [] %}
-
 {% for service_name in pillar['services'] %}
 {%     if pillar['services'][service_name]['type'] | default('compose') == 'ecs' %}
-{%         do service_list.append(pillar['services'][service_name]) %}
+{%         %}
 {%     endif %}
 {% endfor %}
-
-{{ service_list }}

--- a/docker-service/ecs-service.sls
+++ b/docker-service/ecs-service.sls
@@ -1,0 +1,23 @@
+#anatomy of an ecs service.
+# elb is required for managing location of container in cluster, although consul can provide provides the same service via DNS/consul agent
+# elb is required for load balanced access and external access
+# task definition -> json format from template
+# service definition -> aws resource
+# persistent data dirs -> create dirs and deliver config from templates.
+
+#include:
+#  - aws_rds
+#  - aws_elb
+#  - aws_service
+#  - aws_task
+#  - aws_dns
+
+{%     set service_list = [] %}
+
+{% for service_name in pillar['services'] %}
+{%     if pillar['services'][service_name]['type'] | default('compose') == 'ecs' %}
+{%         do service_list.append(pillar['services'][service_name]) %}
+{%     endif %}
+{% endfor %}
+
+{{ service_list }}

--- a/docker-service/ecs-service.sls
+++ b/docker-service/ecs-service.sls
@@ -11,9 +11,3 @@
 #  - aws_service
 #  - aws_task
 #  - aws_dns
-
-{% for service_name in pillar['services'] %}
-{%     if pillar['services'][service_name]['type'] | default('compose') == 'ecs' %}
-{%         %}
-{%     endif %}
-{% endfor %}

--- a/docker-service/init.sls
+++ b/docker-service/init.sls
@@ -2,6 +2,5 @@
 
 {% if 'services' in pillar %}
   - .compose-service
-  - .ecs-service
 {% endif %}
 

--- a/docker-service/init.sls
+++ b/docker-service/init.sls
@@ -1,0 +1,7 @@
+{% from "docker-service/map.jinja" import services with context %}
+
+{% if 'services' in pillar %}
+  - .compose-service
+  - .ecs-service
+{% endif %}
+

--- a/docker-service/init.sls
+++ b/docker-service/init.sls
@@ -1,5 +1,5 @@
 {% from "docker-service/map.jinja" import services with context %}
-
+include:
 {% if 'services' in pillar %}
   - .compose-service
 {% endif %}

--- a/docker-service/map.jinja
+++ b/docker-service/map.jinja
@@ -1,0 +1,8 @@
+{% set services = salt['grains.filter_by']({
+  'compose': {
+    'services': {}
+  },
+  'ecs': {
+    'services': {}
+  }
+}, merge=salt['pillar.get']('services'), default='compose') %}

--- a/docker-service/templates/app.env
+++ b/docker-service/templates/app.env
@@ -1,0 +1,14 @@
+{%  if pillar['services'][service_name]['env_files'] is defined -%}
+{%    for k, v in pillar['services'][service_name]['env_files'][app_name].iteritems() -%}
+{{ k }}={{ v }}
+{%    endfor %}
+{%    if env_extra is defined -%}
+{%      for k, v in pillar['services'][service_name]['extra'][env_extra].iteritems() -%}
+{{ k }}={{ v }}
+{%      endfor %}
+{%    endif %}
+{%  else %}
+{%    for k, v in pillar['services'][service_name][app_name]['env'].iteritems() -%}
+{{ k }}={{ v }}
+{%    endfor %}
+{%  endif %}

--- a/docker-service/templates/docker-compose-service
+++ b/docker-service/templates/docker-compose-service
@@ -1,0 +1,55 @@
+{% from "monitoring/map.jinja" import monitoring with context %}
+#!/bin/bash
+### BEGIN INIT INFO
+# Provides:          docker-compose-{{service_name}}
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 6
+# Short-Description: docker-compose {{service_name}}
+# Description:       Start/stop {{service_name}} containers
+### END INIT INFO
+
+#TODO: add docker-compose output parsing and run conntrack only when needed
+#TODO: replace status with docker-compose parser and checker if containers are running (if really needed)
+
+
+start()
+{
+    /usr/local/bin/docker-compose -p {{service_name}} -f /etc/docker-compose/{{service_name}}/docker-compose.yml up -d
+    ret=$?
+    /usr/sbin/conntrack -D -p udp
+    exit ${ret}
+}
+
+stop()
+{
+    /usr/local/bin/docker-compose -p {{service_name}} -f /etc/docker-compose/{{service_name}}/docker-compose.yml stop
+    /usr/local/bin/docker-compose -p {{service_name}} -f /etc/docker-compose/{{service_name}}/docker-compose.yml kill
+}
+
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  reload)
+    start
+    ;;
+  restart)
+    stop
+    start
+    ;;
+  status)
+    start
+    ;;
+  ps)
+    /usr/local/bin/docker-compose -p {{service_name}} -f /etc/docker-compose/{{service_name}}/docker-compose.yml ps
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|reload|restart|ps}"
+    exit 1
+    ;;
+esac

--- a/docker-service/templates/task.json
+++ b/docker-service/templates/task.json
@@ -1,0 +1,40 @@
+[
+  {
+    "name": "{{ service_name }}",
+    "image": "{{ service_image }}",
+    "essential": true,
+    "memory": {{ service_memory| default(256) }},
+    "cpu": {{ service_cpu | default(1024) }},
+{%- if service_ports is defined %}
+    "portMappings": [
+{%-   for c_port, h_port, proto in service_ports %}
+      {
+        "containerPort": {{ c_port }},
+        "hostPort": {{ h_port }},
+        "protocol": "{{ proto |default('tcp')"
+      },
+{%-   endfor %}
+      {
+        "containerPort": 80,
+        "hostPort": 80,
+        "protocol": "tcp"
+      },
+      {
+        "containerPort": 443,
+        "hostPort": 443,
+        "protocol": "tcp"
+      }
+    ],
+{%- endif %}
+{%- if mount_points is defined %}
+    "mountPoints": [
+{%-   for vol, path in mount_points %}
+      {
+        "sourceVolume": "{{ vol }}",
+        "containerPath": "{{ path }}"
+      },
+{%-   endfor %}
+    ]
+  }
+{%- endif %}
+]

--- a/metadata.yml
+++ b/metadata.yml
@@ -6,6 +6,7 @@ exports:
 - admins
 - docker
 - docker-compose
+- docker-service
 - mongodb
 - mongodb-client
 - monitoring


### PR DESCRIPTION
Log output run against LPA aws-develop environment:
$ fab shaker
Linking opg-collectd-formula:opg-collectd
Linking opg-hardening-formula:hardening
Fetching git@github.com:ministryofjustice/opg-salt-formula.git to see if OPGS-1224-opg_shared_deploy has changed done
Linking opg-salt-formula:base
Linking opg-salt-formula:cron
Linking opg-salt-formula:ntp
Linking opg-salt-formula:bootstrap
Linking opg-salt-formula:admins
Linking opg-salt-formula:docker
Linking opg-salt-formula:docker-compose
Linking opg-salt-formula:docker-service
Linking opg-salt-formula:mongodb
Linking opg-salt-formula:mongodb-client
Linking opg-salt-formula:monitoring

Done.

---

$ sudo salt "ip-10-0-1-105" -l debug state.apply docker-service test=true 
[DEBUG   ] Reading configuration from /etc/salt/master
[DEBUG   ] Using cached minion ID from /etc/salt/minion_id: ip-10-0-1-105
[DEBUG   ] Missing configuration file: /home/tmcarthur/.saltrc
[DEBUG   ] Configuration file path: /etc/salt/master
[WARNING ] Insecure logging configuration detected! Sensitive data may be logged.
[DEBUG   ] Reading configuration from /etc/salt/master
[DEBUG   ] Using cached minion ID from /etc/salt/minion_id: ip-10-0-1-105
[DEBUG   ] Missing configuration file: /home/tmcarthur/.saltrc
[DEBUG   ] MasterEvent PUB socket URI: ipc:///var/run/salt/master/master_event_pub.ipc
[DEBUG   ] MasterEvent PULL socket URI: ipc:///var/run/salt/master/master_event_pull.ipc
[DEBUG   ] Initializing new AsyncZeroMQReqChannel for ('/etc/salt/pki/master', 'ip-10-0-1-105_master', 'tcp://127.0.0.1:4506', 'clear')
[DEBUG   ] LazyLoaded local_cache.get_load
[DEBUG   ] get_iter_returns for jid 20160523144518635979 sent to set(['ip-10-0-1-105']) will timeout at 14:45:23.643642
[DEBUG   ] jid 20160523144518635979 return from ip-10-0-1-105
[DEBUG   ] LazyLoaded highstate.output
ip-10-0-1-105:
  Name: /etc/docker-compose - Function: file.directory - Result: Clean
  Name: /etc/docker-compose/monitoring-client - Function: file.directory - Result: Clean
  Name: /etc/docker-compose/monitoring-client/docker-compose.yml - Function: file.managed - Result: Clean
  Name: /etc/init.d/docker-compose-monitoring-client - Function: file.managed - Result: Clean
  Name: /etc/docker-compose/monitoring-client/checksbase.env - Function: file.managed - Result: Clean
  Name: /etc/docker-compose/monitoring-client/sensuclient.env - Function: file.managed - Result: Clean
  Name: docker-compose-monitoring-client - Function: service.running - Result: Clean
  Name: /etc/docker-compose/master - Function: file.directory - Result: Clean
  Name: /etc/docker-compose/master/docker-compose.yml - Function: file.managed - Result: Clean
  Name: /etc/init.d/docker-compose-master - Function: file.managed - Result: Clean
  Name: /etc/docker-compose/master/scripts.env - Function: file.managed - Result: Clean
  Name: docker-compose-master - Function: service.running - Result: Clean
## Summary for ip-10-0-1-105

Succeeded: 12
## Failed:     0

Total states run:     12
[DEBUG   ] jid 20160523144518635979 found all minions set(['ip-10-0-1-105'])
