### PR TITLE
DAPH-188: increase docker-compose down timeout to 30s vs default of 10s

### DIFF
--- a/docker-service/templates/docker-compose-service
+++ b/docker-service/templates/docker-compose-service
@@ -25,7 +25,7 @@ start()
 
 stop()
 {
-    /usr/local/bin/docker-compose -p {{service_name}} -f /etc/docker-compose/{{service_name}}/docker-compose.yml stop
+    /usr/local/bin/docker-compose -p {{service_name}} -f /etc/docker-compose/{{service_name}}/docker-compose.yml stop -t 30
     /usr/local/bin/docker-compose -p {{service_name}} -f /etc/docker-compose/{{service_name}}/docker-compose.yml kill
 }
 


### PR DESCRIPTION
related to: https://github.com/hardware/mailserver/issues/17#issuecomment-218298999