### PR TITLE
add --remove-orphans

### DIFF
--- a/docker-service/templates/docker-compose-service
+++ b/docker-service/templates/docker-compose-service
@@ -17,7 +17,7 @@
 start()
 {
     /usr/local/bin/docker-compose -p {{service_name}} -f /etc/docker-compose/{{service_name}}/docker-compose.yml pull
-    /usr/local/bin/docker-compose -p {{service_name}} -f /etc/docker-compose/{{service_name}}/docker-compose.yml up -d
+    /usr/local/bin/docker-compose -p {{service_name}} -f /etc/docker-compose/{{service_name}}/docker-compose.yml up --remove-orphans  -d
     ret=$?
     /usr/sbin/conntrack -D -p udp
     exit ${ret}


### PR DESCRIPTION
some errors leading to the docker-compose api is enabled but already dead

docker ps
CONTAINER ID        IMAGE                                                    COMMAND             CREATED             STATUS              PORTS                          NAMES
d28f93e9cfb9        registry.service.opg.digital/opguk/nginx-router:latest   "/sbin/my_init"     35 minutes ago      Up 35 minutes       80/tcp, 0.0.0.0:443->443/tcp   frontend_router_1
 /etc/init.d/docker
docker                   docker-compose-frontend
 /etc/init.d/docker-compose-frontend start
Pulling frontend (registry.service.opg.digital/opguk/core-frontend:0.2.814)...
0.2.814: Pulling from opguk/core-frontend
Digest: sha256:29533e81b67cf2eedf8cfca39787a789fe47b2b7bd5cea6aa2c6d7be9a4d9834
Status: Image is up to date for registry.service.opg.digital/opguk/core-frontend:0.2.814
WARNING: Found orphan containers (frontend_router_1) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.
Removing frontend_frontend_1
Recreating 54bed138d946_54bed138d946_54bed138d946_54bed138d946_54bed138d946_54bed138d946_frontend_frontend_1

ERROR: for frontend  Cannot start service frontend: driver failed programming external connectivity on endpoint frontend_frontend_1 (ff42fdb3a08fa5f69a3ef321ba2a2b6b45b16fc6d044d33f5fe20851130d8b9b): Bind for 0.0.0.0:443 failed: port is already allocated
ERROR: Encountered errors while bringing up the project.