### PR TITLE
Revert "SDV2-1196: make sysV init docker-compose files NOT execute start() on a status() call"

### DIFF
--- a/docker-service/templates/docker-compose-service
+++ b/docker-service/templates/docker-compose-service
@@ -44,7 +44,7 @@ case "$1" in
     start
     ;;
   status)
-    echo "status() mocked out, as there is no docker-compose status command"
+    start
     ;;
   ps)
     /usr/local/bin/docker-compose -p {{service_name}} -f /etc/docker-compose/{{service_name}}/docker-compose.yml ps


### PR DESCRIPTION
This reverts commit dcd88bf4a3c6c0e3b1b3ccdeef26f64107443438.